### PR TITLE
image dependency version upgraded to 0.23.9 followed by small imports…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ branch = "master"
 qrcodegen = "1.6"
 html-escape = "0.2"
 
-image-dep = { package = "image", version = "0.23.7", optional = true }
+image-dep = { package = "image", version = "0.23.9", optional = true }
 
 [dev-dependencies]
 slash-formatter = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ use qrcodegen::QrCode;
 pub use qrcodegen::{QrCodeEcc, QrSegment};
 
 #[cfg(feature = "image")]
-use image::png::{CompressionType, FilterType, PNGEncoder};
+use image::codecs::png::{CompressionType, FilterType, PngEncoder};
 
 #[cfg(feature = "image")]
 use image::{ColorType, ImageBuffer, Luma};
@@ -470,7 +470,7 @@ fn to_image_inner(qr: QrCode, size: usize) -> Result<Vec<u8>, QRCodeError> {
 fn to_png_inner<W: Write>(qr: QrCode, size: usize, writer: W) -> Result<(), QRCodeError> {
     let img_raw = to_image_inner(qr, size)?;
 
-    let encoder = PNGEncoder::new_with_quality(writer, CompressionType::Best, FilterType::NoFilter);
+    let encoder = PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::NoFilter);
 
     Ok(encoder.encode(&img_raw, size as u32, size as u32, ColorType::L8)?)
 }


### PR DESCRIPTION
## What?
I've upgraded the image dependency to version 0.23.9 and made some necessary changes to build the project.

## Why?
Some changes in the Image library caused compilation errors to qrcode-generator. Even though the image library has released as a minor change, what we had is a breaking change.

## How?
This includes changing the image-dep version to a minimum of 0.23.9 wich is the one that has the breaking change. Besides that the PNGEncoder had your name, and path fixed.