### PR TITLE
Add link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 QR Code Generator
 ====================
 
+[![Docs](https://docs.rs/qrcode-generator/badge.svg)](https://docs.rs/qrcode-generator)
 [![CI](https://github.com/magiclen/qrcode-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/magiclen/qrcode-generator/actions/workflows/ci.yml)
 
 This crate provides functions to generate QR Code matrices and images in RAW, PNG and SVG formats.


### PR DESCRIPTION
I think it's usually quite helpful and welcoming of projects to have a link to docs.rs for the respective crate right there in the README.